### PR TITLE
Add training run tracking and pipeline command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+fussball.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
 # fussball-analyse-system
-Open-Source Fussball-Analyse-System (ETL + ML + Dashboard)
+
+Ein einfaches Fussball Analyse System als Ausgangspunkt für weitergehende Entwicklungen. Das Projekt erstellt automatisch eine SQLite Datenbank, kann CSV Dateien einlesen, ein Machine-Learning-Modell trainieren und Prognosen zu kommenden Spielen ausgeben. Vorhersagen werden gespeichert und nach Bekanntwerden der Ergebnisse ausgewertet, so dass das System seinen Lernerfolg kontrollieren kann. Inzwischen verwaltet die Datenbank auch Ligen und Saisons, so dass Daten mehrerer Wettbewerbe zusammengeführt werden können.
+
+Die aktuelle Version berechnet zusätzlich Elo-Werte für Teams und verwendet diese bei der Prognose. Ein Kreuzvalidierungs-Schritt liefert einen realistischeren Eindruck der Modellqualität.
+
+## Voraussetzungen
+
+- Python 3.10+
+- Abhängigkeiten aus `requirements.txt`
+
+Installation der Abhängigkeiten:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Nutzung
+
+1. Datenbank initialisieren und CSV Daten laden:
+
+```bash
+python -m fussball_analyse.cli ingest teams path/zu/teams.csv
+python -m fussball_analyse.cli ingest players path/zu/players.csv
+python -m fussball_analyse.cli ingest matches path/zu/matches.csv
+```
+
+2. Modell trainieren und Prognosen berechnen:
+
+```bash
+python -m fussball_analyse.cli train
+```
+
+3. Kompletten Ablauf mit automatisch heruntergeladenen Daten testen:
+
+```bash
+python -m fussball_analyse.cli demo
+```
+
+Das Programm zeigt Trainingsgenauigkeit und Prognosen für Spiele ohne Ergebnis an. Eine echte selbstverbessernde Pipeline ist hier nur angedeutet und kann weiter ausgebaut werden.
+Das Training speichert die Vorhersagen in der Datenbank. Sobald die realen Resultate eingetragen werden, misst das Programm automatisch die Trefferquote und nutzt die Daten bei jedem erneuten Aufruf von `train`, um das Modell neu zu trainieren.
+Dabei fließen auch aktualisierte Elo-Werte der Teams ein. Die Konsole zeigt zusätzlich eine Kreuzvalidierungs-Genauigkeit an, um die Modellqualität einzuschätzen.
+
+4. Daten der wichtigsten Ligen automatisch synchronisieren und im gleichen Schritt trainieren:
+
+```bash
+python -m fussball_analyse.cli sync
+python -m fussball_analyse.cli train
+```
+
+Der `sync`-Befehl lädt Premier League-, La-Liga-, Serie-A-, Bundesliga- und Lig
+ue‑1-Daten der neuesten Saison direkt von *football-data.co.uk* herunter und legt sie in der Datenbank an. Neue Ligen und Teams werden automatisch angelegt.
+
+Alternativ kann der gesamte Ablauf mit einem einzigen Aufruf gestartet werden:
+
+```bash
+python -m fussball_analyse.cli pipeline
+```
+
+Dabei werden zunächst alle verfügbaren Daten synchronisiert und anschließend direkt das Training inklusive Prognose erstellt. Nach jedem Durchlauf wird ein Datensatz in der Tabelle `training_runs` hinterlegt, um den Fortschritt nachverfolgen zu können.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+SQLAlchemy
+scikit-learn
+requests

--- a/src/fussball_analyse/__init__.py
+++ b/src/fussball_analyse/__init__.py
@@ -1,0 +1,1 @@
+"""Fussball Analyse Paket."""

--- a/src/fussball_analyse/auto_update.py
+++ b/src/fussball_analyse/auto_update.py
@@ -1,0 +1,77 @@
+import io
+from typing import Dict, List
+
+import pandas as pd
+import requests
+from sqlalchemy.orm import Session
+
+from .models import League, Team
+from .data_ingest import load_matches_df
+
+LEAGUE_CODES: Dict[str, str] = {
+    "E0": "Premier League",
+    "SP1": "La Liga",
+    "I1": "Serie A",
+    "D1": "Bundesliga",
+    "F1": "Ligue 1",
+}
+
+BASE_URL = "https://www.football-data.co.uk/mmz4281/{season}/{code}.csv"
+
+
+def fetch_csv(url: str) -> pd.DataFrame | None:
+    try:
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+    except Exception:
+        return None
+    return pd.read_csv(io.StringIO(resp.text))
+
+
+def get_or_create_league(session: Session, code: str, name: str) -> int:
+    league = session.query(League).filter_by(code=code).first()
+    if not league:
+        league = League(code=code, name=name)
+        session.add(league)
+        session.commit()
+    return league.id
+
+
+def get_or_create_team(session: Session, name: str) -> int:
+    team = session.query(Team).filter_by(name=name).first()
+    if not team:
+        team = Team(name=name)
+        session.add(team)
+        session.commit()
+    return team.id
+
+
+def sync_data(session: Session, seasons: List[str] | None = None) -> None:
+    if seasons is None:
+        seasons = ["2324"]
+    for season in seasons:
+        for code, name in LEAGUE_CODES.items():
+            df = fetch_csv(BASE_URL.format(season=season, code=code))
+            if df is None or df.empty:
+                continue
+            league_id = get_or_create_league(session, code, name)
+            df = df.dropna(subset=["HomeTeam", "AwayTeam", "Date"])
+            df["Date"] = pd.to_datetime(df["Date"], dayfirst=True, errors="coerce")
+            conv = pd.DataFrame(
+                {
+                    "date": df["Date"],
+                    "home_team": df["HomeTeam"],
+                    "away_team": df["AwayTeam"],
+                    "home_goals": df.get("FTHG"),
+                    "away_goals": df.get("FTAG"),
+                    "league_id": league_id,
+                    "season": season,
+                }
+            )
+            # ensure teams exist
+            team_map = {
+                name: get_or_create_team(session, name)
+                for name in pd.concat([conv["home_team"], conv["away_team"]]).unique()
+            }
+            load_matches_df(session, conv, team_map)
+

--- a/src/fussball_analyse/cli.py
+++ b/src/fussball_analyse/cli.py
@@ -1,0 +1,55 @@
+import argparse
+
+from .database import SessionLocal, init_db
+from .data_ingest import (
+    load_teams,
+    load_players,
+    load_matches,
+    load_teams_df,
+    load_players_df,
+    load_matches_df,
+)
+from .self_learning import self_improve
+from . import demo as demo_module
+from . import auto_update
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fussball Analyse System")
+    sub = parser.add_subparsers(dest="command")
+
+    ing = sub.add_parser("ingest", help="Load CSV data")
+    ing.add_argument("type", choices=["teams", "players", "matches"])
+    ing.add_argument("csv_file")
+
+    sub.add_parser("train", help="Train and predict")
+    sub.add_parser("demo", help="Fetch online data and run demo training")
+    sub.add_parser("sync", help="Download latest results and update database")
+    sub.add_parser("pipeline", help="Sync data and train in one step")
+
+    args = parser.parse_args()
+    init_db()
+    session = SessionLocal()
+
+    if args.command == "ingest":
+        if args.type == "teams":
+            load_teams(session, args.csv_file)
+        elif args.type == "players":
+            load_players(session, args.csv_file)
+        elif args.type == "matches":
+            load_matches(session, args.csv_file)
+    elif args.command == "train":
+        self_improve(session)
+    elif args.command == "demo":
+        demo_module.run_demo(session)
+    elif args.command == "sync":
+        auto_update.sync_data(session)
+    elif args.command == "pipeline":
+        auto_update.sync_data(session)
+        self_improve(session)
+
+    session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fussball_analyse/data_ingest.py
+++ b/src/fussball_analyse/data_ingest.py
@@ -1,0 +1,95 @@
+import pandas as pd
+from sqlalchemy.orm import Session
+
+from .models import Team, Player, Match, League
+
+
+def load_teams(session: Session, csv_file: str):
+    df = pd.read_csv(csv_file)
+    for _, row in df.iterrows():
+        team = Team(name=row['name'])
+        session.add(team)
+    session.commit()
+
+
+def load_leagues(session: Session, csv_file: str):
+    df = pd.read_csv(csv_file)
+    for _, row in df.iterrows():
+        league = League(code=row['code'], name=row['name'])
+        session.add(league)
+    session.commit()
+
+
+def load_players(session: Session, csv_file: str):
+    df = pd.read_csv(csv_file)
+    for _, row in df.iterrows():
+        player = Player(name=row['name'], position=row.get('position'), team_id=row.get('team_id'))
+        session.add(player)
+    session.commit()
+
+
+def load_matches(session: Session, csv_file: str):
+    df = pd.read_csv(csv_file, parse_dates=['date'])
+    for _, row in df.iterrows():
+        match = Match(
+            date=row['date'],
+            season=row.get('season'),
+            league_id=row.get('league_id'),
+            home_team_id=row['home_team_id'],
+            away_team_id=row['away_team_id'],
+            home_goals=row.get('home_goals'),
+            away_goals=row.get('away_goals'),
+        )
+        session.add(match)
+    session.commit()
+
+
+def load_teams_df(session: Session, df: pd.DataFrame):
+    for _, row in df.iterrows():
+        team = Team(name=row["name"])
+        session.add(team)
+    session.commit()
+
+
+def load_leagues_df(session: Session, df: pd.DataFrame):
+    for _, row in df.iterrows():
+        league = League(code=row["code"], name=row["name"])
+        session.add(league)
+    session.commit()
+
+
+def load_players_df(session: Session, df: pd.DataFrame, team_map: dict[str, int]):
+    for _, row in df.iterrows():
+        team_name = row.get("team")
+        team_id = team_map.get(team_name)
+        player = Player(
+            name=f"{row.get('first_name', '')} {row.get('second_name', '')}".strip(),
+            position=row.get("position"),
+            team_id=team_id,
+        )
+        session.add(player)
+    session.commit()
+
+
+def load_matches_df(session: Session, df: pd.DataFrame, team_map: dict[str, int]):
+    for _, row in df.iterrows():
+        home_id = team_map.get(row["home_team"])
+        away_id = team_map.get(row["away_team"])
+        exists = (
+            session.query(Match)
+            .filter_by(date=row["date"], home_team_id=home_id, away_team_id=away_id)
+            .first()
+        )
+        if exists:
+            continue
+        match = Match(
+            date=row["date"],
+            season=row.get("season"),
+            league_id=row.get("league_id"),
+            home_team_id=home_id,
+            away_team_id=away_id,
+            home_goals=row.get("home_goals"),
+            away_goals=row.get("away_goals"),
+        )
+        session.add(match)
+    session.commit()

--- a/src/fussball_analyse/database.py
+++ b/src/fussball_analyse/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = "sqlite:///fussball.db"
+
+engine = create_engine(DATABASE_URL, echo=False)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/src/fussball_analyse/demo.py
+++ b/src/fussball_analyse/demo.py
@@ -1,0 +1,81 @@
+import io
+from typing import Dict
+
+import pandas as pd
+import requests
+from sqlalchemy.orm import Session
+
+from .data_ingest import load_teams_df, load_players_df, load_matches_df
+from .models import Match, Team
+from .self_learning import self_improve
+
+
+MATCHES_URL = "https://www.football-data.co.uk/mmz4281/2122/E0.csv"
+PLAYERS_URL = (
+    "https://raw.githubusercontent.com/vaastav/Fantasy-Premier-League/master/data/2021-22/players_raw.csv"
+)
+TEAMS_URL = (
+    "https://raw.githubusercontent.com/vaastav/Fantasy-Premier-League/master/data/2021-22/teams.csv"
+)
+
+TEAM_NAME_MAP = {"Man Utd": "Man United", "Spurs": "Tottenham"}
+
+
+def fetch_csv(url: str) -> pd.DataFrame:
+    """Download a CSV file into a DataFrame."""
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return pd.read_csv(io.StringIO(resp.text))
+
+
+def run_demo(session: Session) -> None:
+    """Fetch sample data, train and evaluate on a small holdout set."""
+    matches_df = fetch_csv(MATCHES_URL)
+    teams_df = fetch_csv(TEAMS_URL)
+    players_df = fetch_csv(PLAYERS_URL)
+
+    teams_df["name"] = teams_df["name"].replace(TEAM_NAME_MAP)
+    load_teams_df(session, teams_df[["name"]])
+
+    team_map: Dict[str, int] = {t.name: t.id for t in session.query(Team).all()}
+    players_df["team"] = players_df["team"].map(lambda x: teams_df.loc[x - 1, "name"])  # team is index
+    players_df["team"] = players_df["team"].replace(TEAM_NAME_MAP)
+    load_players_df(session, players_df, team_map)
+
+    matches_df["Date"] = pd.to_datetime(matches_df["Date"], dayfirst=True)
+    matches_df = matches_df.sort_values("Date")
+    holdout = matches_df.tail(10)
+    train_df = matches_df.iloc[:-10]
+
+    def convert(df: pd.DataFrame) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "date": df["Date"],
+                "home_team": df["HomeTeam"].replace(TEAM_NAME_MAP),
+                "away_team": df["AwayTeam"].replace(TEAM_NAME_MAP),
+                "home_goals": df.get("FTHG"),
+                "away_goals": df.get("FTAG"),
+            }
+        )
+
+    load_matches_df(session, convert(train_df), team_map)
+    # holdout matches without results
+    holdout_nores = convert(holdout)
+    holdout_nores["home_goals"] = None
+    holdout_nores["away_goals"] = None
+    load_matches_df(session, holdout_nores, team_map)
+
+    print("Initial training and prediction on holdout matches:")
+    self_improve(session)
+
+    # reveal actual results
+    holdout_matches = (
+        session.query(Match).filter(Match.home_goals == None).order_by(Match.date).all()
+    )
+    for match_obj, (_, row) in zip(holdout_matches, holdout.iterrows()):
+        match_obj.home_goals = int(row["FTHG"])
+        match_obj.away_goals = int(row["FTAG"])
+    session.commit()
+
+    print("\nAfter adding actual results:")
+    self_improve(session)

--- a/src/fussball_analyse/elo.py
+++ b/src/fussball_analyse/elo.py
@@ -1,0 +1,37 @@
+from typing import Optional
+from sqlalchemy.orm import Session
+
+from .models import Team, Match
+
+
+def update_elos(session: Session, k: float = 20.0) -> None:
+    """Update team Elo ratings based on chronological match results."""
+    teams = session.query(Team).all()
+    for team in teams:
+        if team.elo is None:
+            team.elo = 1000.0
+    session.commit()
+
+    matches = (
+        session.query(Match)
+        .filter(Match.home_goals != None)
+        .order_by(Match.date)
+        .all()
+    )
+    for m in matches:
+        home: Optional[Team] = session.get(Team, m.home_team_id)
+        away: Optional[Team] = session.get(Team, m.away_team_id)
+        if not home or not away:
+            continue
+        # expected result probabilities
+        expected_home = 1 / (1 + 10 ** ((away.elo - home.elo) / 400))
+        expected_away = 1 - expected_home
+        if m.home_goals > m.away_goals:
+            score_home, score_away = 1, 0
+        elif m.home_goals < m.away_goals:
+            score_home, score_away = 0, 1
+        else:
+            score_home = score_away = 0.5
+        home.elo += k * (score_home - expected_home)
+        away.elo += k * (score_away - expected_away)
+    session.commit()

--- a/src/fussball_analyse/models.py
+++ b/src/fussball_analyse/models.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Float,
+    Date,
+    DateTime,
+    ForeignKey,
+)
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class Team(Base):
+    __tablename__ = 'teams'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+    players = relationship('Player', back_populates='team')
+    elo = Column(Float, default=1000.0)
+
+
+class League(Base):
+    __tablename__ = 'leagues'
+    id = Column(Integer, primary_key=True)
+    code = Column(String, unique=True, nullable=False)
+    name = Column(String, nullable=False)
+
+class Player(Base):
+    __tablename__ = 'players'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    position = Column(String)
+    team_id = Column(Integer, ForeignKey('teams.id'))
+    team = relationship('Team', back_populates='players')
+
+class Match(Base):
+    __tablename__ = 'matches'
+    id = Column(Integer, primary_key=True)
+    date = Column(Date)
+    season = Column(String)
+    league_id = Column(Integer, ForeignKey('leagues.id'))
+    home_team_id = Column(Integer, ForeignKey('teams.id'))
+    away_team_id = Column(Integer, ForeignKey('teams.id'))
+    home_goals = Column(Integer)
+    away_goals = Column(Integer)
+
+class Rating(Base):
+    __tablename__ = 'ratings'
+    id = Column(Integer, primary_key=True)
+    player_id = Column(Integer, ForeignKey('players.id'))
+    score = Column(Float)
+
+
+class Prediction(Base):
+    __tablename__ = 'predictions'
+    id = Column(Integer, primary_key=True)
+    match_id = Column(Integer, ForeignKey('matches.id'))
+    predicted_result = Column(Integer)  # 1=home win, 0=draw, -1=away win
+    actual_result = Column(Integer, nullable=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    match = relationship('Match')
+
+
+class TrainingRun(Base):
+    """Store metrics for each training session."""
+
+    __tablename__ = 'training_runs'
+
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    training_size = Column(Integer)
+    accuracy = Column(Float)
+    cv_accuracy = Column(Float)

--- a/src/fussball_analyse/predict.py
+++ b/src/fussball_analyse/predict.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from sqlalchemy.orm import Session
+from sklearn.linear_model import LogisticRegression
+
+from .models import Match, Prediction, Team
+
+
+def predict_upcoming(model: LogisticRegression, session: Session) -> pd.DataFrame:
+    """Predict results for matches without scores and store them."""
+    upcoming = session.query(Match).filter(Match.home_goals == None).all()
+    data = []
+    ids = []
+    for m in upcoming:
+        home = session.get(Team, m.home_team_id)
+        away = session.get(Team, m.away_team_id)
+        home_elo = getattr(home, "elo", 1000.0) if home else 1000.0
+        away_elo = getattr(away, "elo", 1000.0) if away else 1000.0
+        data.append([m.home_team_id, m.away_team_id, home_elo - away_elo])
+        ids.append(m.id)
+    X = pd.DataFrame(data, columns=['home_team_id', 'away_team_id', 'elo_diff'])
+    if X.empty:
+        return pd.DataFrame()
+    predictions = model.predict(X)
+    # store predictions in DB
+    for match_id, pred in zip(ids, predictions):
+        p = Prediction(match_id=match_id, predicted_result=int(pred))
+        session.add(p)
+    session.commit()
+    return pd.DataFrame({'match_id': ids, 'prediction': predictions})

--- a/src/fussball_analyse/self_learning.py
+++ b/src/fussball_analyse/self_learning.py
@@ -1,0 +1,70 @@
+from sqlalchemy.orm import Session
+
+from .models import Match, Prediction, TrainingRun
+
+from .predict import predict_upcoming
+from .train import (
+    prepare_training_data,
+    train_model,
+    evaluate_model,
+    cross_validated_score,
+)
+from .elo import update_elos
+
+
+def update_prediction_results(session: Session) -> None:
+    """Match stored predictions with actual results once available."""
+    preds = session.query(Prediction).filter(Prediction.actual_result == None).all()
+    for p in preds:
+        match = session.get(Match, p.match_id)
+        if match and match.home_goals is not None and match.away_goals is not None:
+            if match.home_goals > match.away_goals:
+                p.actual_result = 1
+            elif match.home_goals < match.away_goals:
+                p.actual_result = -1
+            else:
+                p.actual_result = 0
+    session.commit()
+
+
+def evaluate_predictions(session: Session) -> float:
+    """Return accuracy for predictions with known results."""
+    preds = session.query(Prediction).filter(Prediction.actual_result != None).all()
+    if not preds:
+        return 0.0
+    correct = sum(1 for p in preds if p.actual_result == p.predicted_result)
+    return correct / len(preds)
+
+
+def self_improve(session: Session):
+    update_prediction_results(session)
+    update_elos(session)
+    X, y = prepare_training_data(session)
+    if X.empty:
+        print("Not enough data to train.")
+        return
+    cv_score = cross_validated_score(X, y)
+    if cv_score:
+        print(f"Cross-validated accuracy: {cv_score:.2f}")
+    model = train_model(X, y)
+    accuracy = evaluate_model(model, X, y)
+    print(f"Training accuracy: {accuracy:.2f}")
+
+    # Predict upcoming matches
+    preds = predict_upcoming(model, session)
+    if preds.empty:
+        print("No upcoming matches to predict.")
+    else:
+        print(preds)
+
+    pred_acc = evaluate_predictions(session)
+    if pred_acc:
+        print(f"Prediction accuracy so far: {pred_acc:.2f}")
+
+    run = TrainingRun(
+        training_size=len(y),
+        accuracy=float(accuracy),
+        cv_accuracy=float(cv_score),
+    )
+    session.add(run)
+    session.commit()

--- a/src/fussball_analyse/train.py
+++ b/src/fussball_analyse/train.py
@@ -1,0 +1,55 @@
+from typing import Tuple
+
+import pandas as pd
+from sqlalchemy.orm import Session
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import cross_val_score
+
+from .models import Match, Team
+
+
+def prepare_training_data(session: Session) -> Tuple[pd.DataFrame, pd.Series]:
+    matches = session.query(Match).filter(Match.home_goals != None).all()
+    data = []
+    targets = []
+    for m in matches:
+        home = session.get(Team, m.home_team_id)
+        away = session.get(Team, m.away_team_id)
+        home_elo = getattr(home, "elo", 1000.0) if home else 1000.0
+        away_elo = getattr(away, "elo", 1000.0) if away else 1000.0
+        data.append([
+            m.home_team_id,
+            m.away_team_id,
+            home_elo - away_elo,
+        ])
+        if m.home_goals > m.away_goals:
+            targets.append(1)
+        elif m.home_goals < m.away_goals:
+            targets.append(-1)
+        else:
+            targets.append(0)
+    df = pd.DataFrame(data, columns=['home_team_id', 'away_team_id', 'elo_diff'])
+    target_series = pd.Series(targets)
+    return df, target_series
+
+
+def train_model(X: pd.DataFrame, y: pd.Series) -> LogisticRegression:
+    model = LogisticRegression()
+    model.fit(X, y)
+    return model
+
+
+def evaluate_model(model: LogisticRegression, X: pd.DataFrame, y: pd.Series) -> float:
+    preds = model.predict(X)
+    return accuracy_score(y, preds)
+
+
+def cross_validated_score(X: pd.DataFrame, y: pd.Series, folds: int = 5) -> float:
+    """Return mean accuracy using cross-validation."""
+    if len(y) < 2:
+        return 0.0
+    model = LogisticRegression()
+    scores = cross_val_score(model, X, y, cv=min(folds, len(y)))
+    return float(scores.mean())
+


### PR DESCRIPTION
## Summary
- store per-training metrics in new `TrainingRun` table
- avoid duplicate match imports
- extend league sync to Bundesliga and Ligue 1
- add `pipeline` CLI command running sync and training together
- document new workflow in the README

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m fussball_analyse.cli --help`
- `PYTHONPATH=src python -m fussball_analyse.cli pipeline`

------
https://chatgpt.com/codex/tasks/task_e_68514fa38758832a9e86f1de4c57cfc0